### PR TITLE
Replace deprecated function.

### DIFF
--- a/plugins/thumbnail/xvpics.c
+++ b/plugins/thumbnail/xvpics.c
@@ -141,6 +141,7 @@ get_path (const gchar *filename, const gchar *cache_type)
    gchar *image_name;
    gchar *abspath, *image_dir;
    gchar buf[MAX_PATH_LEN];
+   gchar *result;
 
    g_return_val_if_fail (filename, NULL);
    g_return_val_if_fail (cache_type, NULL);
@@ -149,27 +150,24 @@ get_path (const gchar *filename, const gchar *cache_type)
 
    abspath = relpath2abs (filename);
 
-   /* get filename */
    image_name = g_path_get_basename (abspath);
-   if (!image_name) goto ERROR;
-
    /* get dir name */
    image_dir = g_dirname (abspath);
-   if (!image_dir) goto ERROR;
-
-   g_snprintf (buf, MAX_PATH_LEN, "%s/%s/%s",
-               image_dir, XV_THUMNAIL_DIRECTORY, image_name);
 
    g_free (abspath);
-   g_free (image_name);
-   g_free (image_dir);
-   return g_strdup (buf);
 
-ERROR:
-   g_free (abspath);
+   if (image_name && image_dir) {
+      g_snprintf (buf, MAX_PATH_LEN, "%s/%s/%s",
+                  image_dir, XV_THUMNAIL_DIRECTORY, image_name);
+      result = g_strdup (buf);
+   } else {
+      result = NULL;
+   }
+
    g_free (image_name);
    g_free (image_dir);
-   return NULL;
+
+   return result;
 }
 
 

--- a/plugins/thumbnail/xvpics.c
+++ b/plugins/thumbnail/xvpics.c
@@ -167,6 +167,8 @@ get_path (const gchar *filename, const gchar *cache_type)
 
 ERROR:
    g_free (abspath);
+   g_free (image_name);
+   g_free (image_dir);
    return NULL;
 }
 

--- a/plugins/thumbnail/xvpics.c
+++ b/plugins/thumbnail/xvpics.c
@@ -150,7 +150,7 @@ get_path (const gchar *filename, const gchar *cache_type)
    abspath = relpath2abs (filename);
 
    /* get filename */
-   image_name = g_basename (abspath);
+   image_name = g_path_get_basename (abspath);
    if (!image_name) goto ERROR;
 
    /* get dir name */

--- a/plugins/thumbnail/xvpics.c
+++ b/plugins/thumbnail/xvpics.c
@@ -138,7 +138,7 @@ ERROR:
 static gchar *
 get_path (const gchar *filename, const gchar *cache_type)
 {
-   const gchar *image_name;
+   gchar *image_name;
    gchar *abspath, *image_dir;
    gchar buf[MAX_PATH_LEN];
 

--- a/plugins/thumbnail/xvpics.c
+++ b/plugins/thumbnail/xvpics.c
@@ -161,6 +161,7 @@ get_path (const gchar *filename, const gchar *cache_type)
                image_dir, XV_THUMNAIL_DIRECTORY, image_name);
 
    g_free (abspath);
+   g_free (image_name);
    g_free (image_dir);
    return g_strdup (buf);
 

--- a/plugins/thumbnail_view/detailview.c
+++ b/plugins/thumbnail_view/detailview.c
@@ -343,7 +343,7 @@ column_data_filename (GimvThumb *thumb)
    */
 
    {
-      const gchar *filename;
+      gchar *filename;
       gchar *retval;
 
       if (tv->mode == GIMV_THUMB_VIEW_MODE_DIR) {

--- a/plugins/thumbnail_view/detailview.c
+++ b/plugins/thumbnail_view/detailview.c
@@ -347,11 +347,14 @@ column_data_filename (GimvThumb *thumb)
       gchar *retval;
 
       if (tv->mode == GIMV_THUMB_VIEW_MODE_DIR)
+      {
          filename = g_path_get_basename (gimv_image_info_get_path (thumb->info));
-      else
+         retval = gimv_filename_to_internal (filename);
+         g_free (filename);
+      } else {
          filename = gimv_image_info_get_path (thumb->info);
-
-      retval = gimv_filename_to_internal (filename);
+         retval = gimv_filename_to_internal (filename);
+      }
 
       return retval;
    }

--- a/plugins/thumbnail_view/detailview.c
+++ b/plugins/thumbnail_view/detailview.c
@@ -337,7 +337,7 @@ column_data_filename (GimvThumb *thumb)
 
    /*
    if (tv->mode == THUMB_VIEW_MODE_DIR)
-      return g_strdup (g_path_get_basename (thumb->info->filename));
+      return g_path_get_basename (thumb->info->filename);
    else
       return g_strdup (thumb->info->filename);
    */
@@ -346,15 +346,14 @@ column_data_filename (GimvThumb *thumb)
       const gchar *filename;
       gchar *retval;
 
-      if (tv->mode == GIMV_THUMB_VIEW_MODE_DIR)
-      {
+      if (tv->mode == GIMV_THUMB_VIEW_MODE_DIR) {
          filename = g_path_get_basename (gimv_image_info_get_path (thumb->info));
-         retval = gimv_filename_to_internal (filename);
-         g_free (filename);
       } else {
          filename = gimv_image_info_get_path (thumb->info);
-         retval = gimv_filename_to_internal (filename);
       }
+
+      retval = gimv_filename_to_internal (filename);
+      g_free (filename);
 
       return retval;
    }

--- a/plugins/thumbnail_view/detailview.c
+++ b/plugins/thumbnail_view/detailview.c
@@ -337,7 +337,7 @@ column_data_filename (GimvThumb *thumb)
 
    /*
    if (tv->mode == THUMB_VIEW_MODE_DIR)
-      return g_strdup (g_basename (thumb->info->filename));
+      return g_strdup (g_path_get_basename (thumb->info->filename));
    else
       return g_strdup (thumb->info->filename);
    */
@@ -347,7 +347,7 @@ column_data_filename (GimvThumb *thumb)
       gchar *retval;
 
       if (tv->mode == GIMV_THUMB_VIEW_MODE_DIR)
-         filename = g_basename (gimv_image_info_get_path (thumb->info));
+         filename = g_path_get_basename (gimv_image_info_get_path (thumb->info));
       else
          filename = gimv_image_info_get_path (thumb->info);
 

--- a/plugins/thumbnail_view/detailview.c
+++ b/plugins/thumbnail_view/detailview.c
@@ -348,12 +348,12 @@ column_data_filename (GimvThumb *thumb)
 
       if (tv->mode == GIMV_THUMB_VIEW_MODE_DIR) {
          filename = g_path_get_basename (gimv_image_info_get_path (thumb->info));
+         retval = gimv_filename_to_internal (filename);
+         g_free (filename);
       } else {
          filename = gimv_image_info_get_path (thumb->info);
+         retval = gimv_filename_to_internal (filename);
       }
-
-      retval = gimv_filename_to_internal (filename);
-      g_free (filename);
 
       return retval;
    }

--- a/src/gimv_dir_view.c
+++ b/src/gimv_dir_view.c
@@ -500,13 +500,13 @@ cb_tree_expand (GtkTreeView *treeview,
       gchar *path = node->data;
       gboolean dot_file_check;
 
-      dot_file_check = g_basename(path)[0] != '.'
-         || (dv->show_dotfile && g_basename(path)[0] == '.')
-         || (conf.dirview_show_current_dir && !strcmp (g_basename(path), "."))
-         || (conf.dirview_show_parent_dir  && !strcmp (g_basename(path), ".."));
+      dot_file_check = g_path_get_basename(path)[0] != '.'
+         || (dv->show_dotfile && g_path_get_basename(path)[0] == '.')
+         || (conf.dirview_show_current_dir && !strcmp (g_path_get_basename(path), "."))
+         || (conf.dirview_show_parent_dir  && !strcmp (g_path_get_basename(path), ".."));
 
       if (isdir (path) && dot_file_check) {
-         insert_row (store, &iter, parent_iter, g_basename (path), path);
+         insert_row (store, &iter, parent_iter, g_path_get_basename (path), path);
       }
    }
    g_list_foreach (subdir_list, (GFunc) g_free, NULL);

--- a/src/gimv_dir_view.c
+++ b/src/gimv_dir_view.c
@@ -499,17 +499,17 @@ cb_tree_expand (GtkTreeView *treeview,
    for (node = subdir_list; node; node = g_list_next (node)) {
       gchar *path = node->data;
       gboolean dot_file_check;
-      const gchar *bn = g_path_get_basename (path);
+      gchar *basename = g_path_get_basename (path);
 
-      dot_file_check = bn[0] != '.'
-         || (dv->show_dotfile && bn[0] == '.')
-         || (conf.dirview_show_current_dir && !strcmp (bn, "."))
-         || (conf.dirview_show_parent_dir  && !strcmp (bn, ".."));
+      dot_file_check = basename[0] != '.'
+         || (dv->show_dotfile && basename[0] == '.')
+         || (conf.dirview_show_current_dir && !strcmp (basename, "."))
+         || (conf.dirview_show_parent_dir  && !strcmp (basename, ".."));
 
       if (isdir (path) && dot_file_check) {
-         insert_row (store, &iter, parent_iter, bn, path);
+         insert_row (store, &iter, parent_iter, basename, path);
       }
-      g_free (bn);
+      g_free (basename);
    }
 
    g_list_foreach (subdir_list, (GFunc) g_free, NULL);

--- a/src/gimv_dir_view.c
+++ b/src/gimv_dir_view.c
@@ -499,16 +499,19 @@ cb_tree_expand (GtkTreeView *treeview,
    for (node = subdir_list; node; node = g_list_next (node)) {
       gchar *path = node->data;
       gboolean dot_file_check;
+      const gchar *bn = g_path_get_basename (path);
 
-      dot_file_check = g_path_get_basename(path)[0] != '.'
-         || (dv->show_dotfile && g_path_get_basename(path)[0] == '.')
-         || (conf.dirview_show_current_dir && !strcmp (g_path_get_basename(path), "."))
-         || (conf.dirview_show_parent_dir  && !strcmp (g_path_get_basename(path), ".."));
+      dot_file_check = bn[0] != '.'
+         || (dv->show_dotfile && bn[0] == '.')
+         || (conf.dirview_show_current_dir && !strcmp (bn, "."))
+         || (conf.dirview_show_parent_dir  && !strcmp (bn, ".."));
 
       if (isdir (path) && dot_file_check) {
-         insert_row (store, &iter, parent_iter, g_path_get_basename (path), path);
+         insert_row (store, &iter, parent_iter, bn, path);
       }
+      g_free (bn);
    }
+
    g_list_foreach (subdir_list, (GFunc) g_free, NULL);
    g_list_free (subdir_list);
 

--- a/src/gimv_image_win.c
+++ b/src/gimv_image_win.c
@@ -1106,7 +1106,7 @@ gimv_image_win_set_window_title (GimvImageWin *iw)
    if (!g_list_find (gimv_image_view_get_list(), iw->iv)) return;
 
    if (iw->iv->info && gimv_image_info_get_path (iw->iv->info)) {
-      filename = g_basename (iw->iv->info->filename);
+      filename = g_path_get_basename (iw->iv->info->filename);
       dirname = g_dirname (iw->iv->info->filename);
    } else {
       gtk_window_set_title (GTK_WINDOW (iw), GIMV_PROG_NAME);

--- a/src/gimv_image_win.c
+++ b/src/gimv_image_win.c
@@ -1142,6 +1142,7 @@ gimv_image_win_set_window_title (GimvImageWin *iw)
 
    g_free (tmpstr1);
    g_free (tmpstr2);
+   g_free (filename);
    g_free (dirname);
 }
 

--- a/src/gimv_image_win.c
+++ b/src/gimv_image_win.c
@@ -1095,7 +1095,7 @@ static void
 gimv_image_win_set_window_title (GimvImageWin *iw)
 {
    gchar buf[BUF_SIZE];
-   const gchar *filename = NULL;
+   gchar *filename = NULL;
    gchar *dirname = NULL, *tmpstr1, *tmpstr2;
    gboolean keep_buffer;
 

--- a/src/gimv_prefs_win.c
+++ b/src/gimv_prefs_win.c
@@ -220,7 +220,7 @@ prefs_win_create_page (GimvPrefsWinPagePrivate *priv)
 
    /* translate page title */
    if (priv->page->path)
-      title = g_basename (_(priv->page->path));
+      title = g_path_get_basename (_(priv->page->path));
 
    /* create page */
    if (priv->page->create_page_fn) {
@@ -505,7 +505,7 @@ prefs_win_create_navtree (void)
       if (!page || !page->path) continue;
 
       /* translate page title */
-      title = g_basename (_(page->path));
+      title = g_path_get_basename (_(page->path));
 
       /* get node icon */
       get_icon (page->icon,      &pixmap,  &mask);

--- a/src/gimv_prefs_win.c
+++ b/src/gimv_prefs_win.c
@@ -212,7 +212,7 @@ prefs_win_free_strings (gboolean value_changed)
 static void
 prefs_win_create_page (GimvPrefsWinPagePrivate *priv)
 {
-   const gchar *title = NULL;
+   gchar *title = NULL;
    GtkWidget *vbox, *label;
 
    if (!priv || !priv->page) return;
@@ -498,7 +498,7 @@ prefs_win_create_navtree (void)
    /* create pages */
    for (node = get_page_entries_list(); node; node = g_list_next (node)) {
       GimvPrefsWinPage *page = node->data;
-      const gchar *title;
+      gchar *title;
       GdkPixmap *pixmap = NULL, *opixmap = NULL;
       GdkBitmap *mask = NULL, *omask = NULL;
       GimvPrefsWinPagePrivate *priv;

--- a/src/gimv_prefs_win.c
+++ b/src/gimv_prefs_win.c
@@ -230,6 +230,8 @@ prefs_win_create_page (GimvPrefsWinPagePrivate *priv)
                                 vbox, label);
       priv->widget = vbox;
    }
+
+   g_free (title);
 }
 
 
@@ -531,6 +533,8 @@ prefs_win_create_navtree (void)
                           COLUMN_NAME,            title,
                           COLUMN_PRIV_DATA,       priv,
                           COLUMN_TERMINATOR);
+
+      g_free (title);
    }
 
    return tree;

--- a/src/gimv_thumb_view.c
+++ b/src/gimv_thumb_view.c
@@ -1149,9 +1149,9 @@ comp_func_spel (gconstpointer data1, gconstpointer data2)
    else if (!filename2 || !*filename2)
       return 1;
 
-   if (filename1 && !strcmp ("..", g_basename (filename1))) {
+   if (filename1 && !strcmp ("..", g_path_get_basename (filename1))) {
       comp = -1;
-   } else if (filename2 && !strcmp ("..", g_basename (filename2))) {
+   } else if (filename2 && !strcmp ("..", g_path_get_basename (filename2))) {
       comp = 1;
    } else if (!ignore_dir && isdir (filename1) && !isdir (filename2)) {
       comp = -1;
@@ -2038,7 +2038,7 @@ gimv_thumb_view_open_image (GimvThumbView *tv, GimvThumb *thumb, gint type)
    g_return_if_fail (image_name && *image_name);
    filename = g_strdup (image_name);
 
-   if (!strcmp ("..", g_basename (filename))) {
+   if (!strcmp ("..", g_path_get_basename (filename))) {
       tmpstr = filename;
       filename = g_dirname (filename);
       g_free (tmpstr);
@@ -2353,7 +2353,7 @@ gimv_thumb_view_rename_file (GimvThumbView *tv)
    {   /********** convert charset **********/
       gchar *tmpstr, *src_file_internal;
 
-      src_file = g_basename(gimv_image_info_get_path (thumb->info));
+      src_file = g_path_get_basename(gimv_image_info_get_path (thumb->info));
       src_file_internal = charset_to_internal (src_file,
                                                conf.charset_filename,
                                                conf.charset_auto_detect_fn,
@@ -2375,7 +2375,7 @@ gimv_thumb_view_rename_file (GimvThumbView *tv)
    if (!strcmp (src_file, dest_file)) goto ERROR0;
 
    dirname = g_dirname (gimv_image_info_get_path (thumb->info));
-   dest_path = g_strconcat (dirname, "/", g_basename (dest_file), NULL);
+   dest_path = g_strconcat (dirname, "/", g_path_get_basename (dest_file), NULL);
    g_free (dirname);
    exist = !lstat(dest_path, &dest_st);
    if (exist) {
@@ -2538,9 +2538,9 @@ create_scripts_submenu (GimvThumbView *tv)
       if (!filename || !*filename || !isexecutable(filename)) continue;
 
       if (conf.scripts_show_dialog)
-         label = g_strconcat (g_basename (filename), "...", NULL);
+         label = g_strconcat (g_path_get_basename (filename), "...", NULL);
       else
-         label = g_strdup (g_basename (filename));
+         label = g_strdup (g_path_get_basename (filename));
 
       menu_item = gtk_menu_item_new_with_label (label);
       g_object_set_data_full (G_OBJECT (menu_item),
@@ -3448,7 +3448,7 @@ gimv_thumb_view_reset_tab_label (GimvThumbView *tv, const gchar *title)
          tmpstr = fileutil_home2tilde (filename);
       } else {
          if (tv->mode == GIMV_THUMB_VIEW_MODE_ARCHIVE) {
-            tmpstr = g_strdup (g_basename (filename));
+            tmpstr = g_strdup (g_path_get_basename (filename));
          } else {
             gchar *dirname = g_dirname (filename);
             tmpstr = fileutil_dir_basename (dirname);

--- a/src/gimv_thumb_view.c
+++ b/src/gimv_thumb_view.c
@@ -1149,11 +1149,11 @@ comp_func_spel (gconstpointer data1, gconstpointer data2)
    else if (!filename2 || !*filename2)
       return 1;
 
-   const gchar *bn1 = g_path_get_basename (filename1);
-   const gchar *bn2 = g_path_get_basename (filename2);
-   if (filename1 && !strcmp ("..", bn1)) {
+   gchar *basename1 = g_path_get_basename (filename1);
+   gchar *basename2 = g_path_get_basename (filename2);
+   if (filename1 && !strcmp ("..", basename1)) {
       comp = -1;
-   } else if (filename2 && !strcmp ("..", bn2)) {
+   } else if (filename2 && !strcmp ("..", basename2)) {
       comp = 1;
    } else if (!ignore_dir && isdir (filename1) && !isdir (filename2)) {
       comp = -1;
@@ -1165,8 +1165,8 @@ comp_func_spel (gconstpointer data1, gconstpointer data2)
       else
          comp = strcmp ((gchar *) filename1, (gchar *) filename2);
    }
-   g_free (bn1);
-   g_free (bn2);
+   g_free (basename1);
+   g_free (basename2);
 
    return comp;
 }
@@ -2042,8 +2042,8 @@ gimv_thumb_view_open_image (GimvThumbView *tv, GimvThumb *thumb, gint type)
    g_return_if_fail (image_name && *image_name);
    filename = g_strdup (image_name);
 
-   const gchar *bn = g_path_get_basename (filename);
-   if (!strcmp ("..", bn)) {
+   gchar *basename = g_path_get_basename (filename);
+   if (!strcmp ("..", basename)) {
       tmpstr = filename;
       filename = g_dirname (filename);
       g_free (tmpstr);
@@ -2054,7 +2054,7 @@ gimv_thumb_view_open_image (GimvThumbView *tv, GimvThumb *thumb, gint type)
       }
       tmpstr = NULL;
    }
-   g_free (bn);
+   g_free (basename);
 
    /* open directory */
    if (isdir (filename)) {
@@ -2335,7 +2335,7 @@ gimv_thumb_view_rename_file (GimvThumbView *tv)
    GimvThumb *thumb;
    const gchar *cache_type;
    GList *thumblist;
-   const gchar *src_file;
+   gchar *src_file;
    gchar *dest_file, *dest_path;
    gchar *src_cache_path, *dest_cache_path;
    gchar *src_comment, *dest_comment;
@@ -2381,10 +2381,10 @@ gimv_thumb_view_rename_file (GimvThumbView *tv)
    if (!strcmp (src_file, dest_file)) goto ERROR0;
 
    dirname = g_dirname (gimv_image_info_get_path (thumb->info));
-   const gchar *bn = g_path_get_basename (dest_file);
-   dest_path = g_strconcat (dirname, "/", bn, NULL);
+   gchar *basename = g_path_get_basename (dest_file);
+   dest_path = g_strconcat (dirname, "/", basename, NULL);
    g_free (dirname);
-   g_free (bn);
+   g_free (basename);
    exist = !lstat(dest_path, &dest_st);
    if (exist) {
       {   /********** convert charset **********/
@@ -2547,12 +2547,12 @@ create_scripts_submenu (GimvThumbView *tv)
 
       if (!filename || !*filename || !isexecutable(filename)) continue;
 
-      const gchar *bn = g_path_get_basename (filename);
+      gchar *basename = g_path_get_basename (filename);
       if (conf.scripts_show_dialog)
-         label = g_strconcat (bn, "...", NULL);
+         label = g_strconcat (basename, "...", NULL);
       else
-         label = g_strdup (bn);
-      g_free (bn);
+         label = g_strdup (basename);
+      g_free (basename);
 
       menu_item = gtk_menu_item_new_with_label (label);
       g_object_set_data_full (G_OBJECT (menu_item),
@@ -3460,9 +3460,9 @@ gimv_thumb_view_reset_tab_label (GimvThumbView *tv, const gchar *title)
          tmpstr = fileutil_home2tilde (filename);
       } else {
          if (tv->mode == GIMV_THUMB_VIEW_MODE_ARCHIVE) {
-            const gchar *bn = g_path_get_basename (filename);
-            tmpstr = g_strdup (bn);
-            g_free (bn);
+            gchar *basename = g_path_get_basename (filename);
+            tmpstr = g_strdup (basename);
+            g_free (basename);
          } else {
             gchar *dirname = g_dirname (filename);
             tmpstr = fileutil_dir_basename (dirname);

--- a/src/gimv_thumb_view.c
+++ b/src/gimv_thumb_view.c
@@ -2547,12 +2547,13 @@ create_scripts_submenu (GimvThumbView *tv)
 
       if (!filename || !*filename || !isexecutable(filename)) continue;
 
-      gchar *basename = g_path_get_basename (filename);
-      if (conf.scripts_show_dialog)
+      if (conf.scripts_show_dialog) {
+         gchar *basename = g_path_get_basename (filename);
          label = g_strconcat (basename, "...", NULL);
-      else
-         label = g_strdup (basename);
-      g_free (basename);
+         g_free (basename);
+      } else {
+         label = g_path_get_basename (filename);
+      }
 
       menu_item = gtk_menu_item_new_with_label (label);
       g_object_set_data_full (G_OBJECT (menu_item),
@@ -3460,9 +3461,7 @@ gimv_thumb_view_reset_tab_label (GimvThumbView *tv, const gchar *title)
          tmpstr = fileutil_home2tilde (filename);
       } else {
          if (tv->mode == GIMV_THUMB_VIEW_MODE_ARCHIVE) {
-            gchar *basename = g_path_get_basename (filename);
-            tmpstr = g_strdup (basename);
-            g_free (basename);
+            tmpstr = g_path_get_basename (filename);
          } else {
             gchar *dirname = g_dirname (filename);
             tmpstr = fileutil_dir_basename (dirname);

--- a/src/gimv_thumb_view.c
+++ b/src/gimv_thumb_view.c
@@ -1149,9 +1149,11 @@ comp_func_spel (gconstpointer data1, gconstpointer data2)
    else if (!filename2 || !*filename2)
       return 1;
 
-   if (filename1 && !strcmp ("..", g_path_get_basename (filename1))) {
+   const gchar *bn1 = g_path_get_basename (filename1);
+   const gchar *bn2 = g_path_get_basename (filename2);
+   if (filename1 && !strcmp ("..", bn1)) {
       comp = -1;
-   } else if (filename2 && !strcmp ("..", g_path_get_basename (filename2))) {
+   } else if (filename2 && !strcmp ("..", bn2)) {
       comp = 1;
    } else if (!ignore_dir && isdir (filename1) && !isdir (filename2)) {
       comp = -1;
@@ -1163,6 +1165,8 @@ comp_func_spel (gconstpointer data1, gconstpointer data2)
       else
          comp = strcmp ((gchar *) filename1, (gchar *) filename2);
    }
+   g_free (bn1);
+   g_free (bn2);
 
    return comp;
 }
@@ -2038,7 +2042,8 @@ gimv_thumb_view_open_image (GimvThumbView *tv, GimvThumb *thumb, gint type)
    g_return_if_fail (image_name && *image_name);
    filename = g_strdup (image_name);
 
-   if (!strcmp ("..", g_path_get_basename (filename))) {
+   const gchar *bn = g_path_get_basename (filename);
+   if (!strcmp ("..", bn)) {
       tmpstr = filename;
       filename = g_dirname (filename);
       g_free (tmpstr);
@@ -2049,6 +2054,7 @@ gimv_thumb_view_open_image (GimvThumbView *tv, GimvThumb *thumb, gint type)
       }
       tmpstr = NULL;
    }
+   g_free (bn);
 
    /* open directory */
    if (isdir (filename)) {
@@ -2353,7 +2359,7 @@ gimv_thumb_view_rename_file (GimvThumbView *tv)
    {   /********** convert charset **********/
       gchar *tmpstr, *src_file_internal;
 
-      src_file = g_path_get_basename(gimv_image_info_get_path (thumb->info));
+      src_file = g_path_get_basename (gimv_image_info_get_path (thumb->info));
       src_file_internal = charset_to_internal (src_file,
                                                conf.charset_filename,
                                                conf.charset_auto_detect_fn,
@@ -2375,8 +2381,10 @@ gimv_thumb_view_rename_file (GimvThumbView *tv)
    if (!strcmp (src_file, dest_file)) goto ERROR0;
 
    dirname = g_dirname (gimv_image_info_get_path (thumb->info));
-   dest_path = g_strconcat (dirname, "/", g_path_get_basename (dest_file), NULL);
+   const gchar *bn = g_path_get_basename (dest_file);
+   dest_path = g_strconcat (dirname, "/", bn, NULL);
    g_free (dirname);
+   g_free (bn);
    exist = !lstat(dest_path, &dest_st);
    if (exist) {
       {   /********** convert charset **********/
@@ -2398,6 +2406,8 @@ gimv_thumb_view_rename_file (GimvThumbView *tv)
                                         GTK_WINDOW (tv->tw));
       if (confirm == CONFIRM_NO) goto ERROR1;
    }
+
+   g_free (src_file);
 
    /* rename file!! */
    if (rename (gimv_image_info_get_path (thumb->info), dest_path) < 0) {
@@ -2537,10 +2547,12 @@ create_scripts_submenu (GimvThumbView *tv)
 
       if (!filename || !*filename || !isexecutable(filename)) continue;
 
+      const gchar *bn = g_path_get_basename (filename);
       if (conf.scripts_show_dialog)
-         label = g_strconcat (g_path_get_basename (filename), "...", NULL);
+         label = g_strconcat (bn, "...", NULL);
       else
-         label = g_strdup (g_path_get_basename (filename));
+         label = g_strdup (bn);
+      g_free (bn);
 
       menu_item = gtk_menu_item_new_with_label (label);
       g_object_set_data_full (G_OBJECT (menu_item),
@@ -3448,7 +3460,9 @@ gimv_thumb_view_reset_tab_label (GimvThumbView *tv, const gchar *title)
          tmpstr = fileutil_home2tilde (filename);
       } else {
          if (tv->mode == GIMV_THUMB_VIEW_MODE_ARCHIVE) {
-            tmpstr = g_strdup (g_path_get_basename (filename));
+            const gchar *bn = g_path_get_basename (filename);
+            tmpstr = g_strdup (bn);
+            g_free (bn);
          } else {
             gchar *dirname = g_dirname (filename);
             tmpstr = fileutil_dir_basename (dirname);

--- a/src/gimv_thumb_view_album.c
+++ b/src/gimv_thumb_view_album.c
@@ -700,7 +700,7 @@ static const gchar *data_order = DEFAULT_DATA_ORDER;
 static gchar *
 label_filename (GimvThumb *thumb)
 {
-   const gchar *filename;
+   gchar *filename;
    gchar *tmpstr;
    gchar buf[BUF_SIZE];
 

--- a/src/gimv_thumb_view_album.c
+++ b/src/gimv_thumb_view_album.c
@@ -706,7 +706,7 @@ label_filename (GimvThumb *thumb)
 
    g_return_val_if_fail (GIMV_IS_THUMB (thumb), NULL);
 
-   *filename = g_path_get_basename (gimv_image_info_get_path (thumb->info));
+   filename = g_path_get_basename (gimv_image_info_get_path (thumb->info));
    tmpstr = gimv_filename_to_internal (filename);
    g_free (filename);
 

--- a/src/gimv_thumb_view_album.c
+++ b/src/gimv_thumb_view_album.c
@@ -355,7 +355,7 @@ thumbalbum_append_thumb_frame (GimvThumbView *tv, GimvThumb *thumb,
 
    pos = g_list_index (tv->thumblist, thumb);
 
-   filename = g_basename(gimv_image_info_get_path (thumb->info));
+   filename = g_path_get_basename(gimv_image_info_get_path (thumb->info));
 
    if (!strcmp (dest_mode, THUMBALBUM3_LABEL)) {
       label = album_create_label_str (thumb);
@@ -705,7 +705,7 @@ label_filename (GimvThumb *thumb)
 
    g_return_val_if_fail (GIMV_IS_THUMB (thumb), NULL);
 
-   filename = g_basename(gimv_image_info_get_path (thumb->info));
+   filename = g_path_get_basename(gimv_image_info_get_path (thumb->info));
 
    tmpstr = gimv_filename_to_internal (filename);
 

--- a/src/gimv_thumb_view_album.c
+++ b/src/gimv_thumb_view_album.c
@@ -355,13 +355,14 @@ thumbalbum_append_thumb_frame (GimvThumbView *tv, GimvThumb *thumb,
 
    pos = g_list_index (tv->thumblist, thumb);
 
-   filename = g_path_get_basename(gimv_image_info_get_path (thumb->info));
+   filename = g_path_get_basename (gimv_image_info_get_path (thumb->info));
 
    if (!strcmp (dest_mode, THUMBALBUM3_LABEL)) {
       label = album_create_label_str (thumb);
    } else {
       label = gimv_filename_to_internal (filename);
    }
+   g_free (filename);
 
    idx = gimv_zalbum_insert (GIMV_ZALBUM (tv_data->album), pos, label);
    g_free (label);
@@ -705,9 +706,9 @@ label_filename (GimvThumb *thumb)
 
    g_return_val_if_fail (GIMV_IS_THUMB (thumb), NULL);
 
-   filename = g_path_get_basename(gimv_image_info_get_path (thumb->info));
-
+   *filename = g_path_get_basename (gimv_image_info_get_path (thumb->info));
    tmpstr = gimv_filename_to_internal (filename);
+   g_free (filename);
 
    if (show_data_title)
       g_snprintf (buf, BUF_SIZE, _("Name : %s"), tmpstr);

--- a/src/help.c
+++ b/src/help.c
@@ -331,7 +331,7 @@ get_dirlist_sub_menu (const gchar *dir, gpointer func, GList **filelist)
 
       if (!filename) continue;
 
-      menuitem = gtk_menu_item_new_with_label (g_basename(filename));
+      menuitem = gtk_menu_item_new_with_label (g_path_get_basename(filename));
       g_signal_connect (G_OBJECT (menuitem), "activate",
                         G_CALLBACK (func), filename);
       gtk_menu_append (GTK_MENU (menu), menuitem);

--- a/src/help.c
+++ b/src/help.c
@@ -331,7 +331,9 @@ get_dirlist_sub_menu (const gchar *dir, gpointer func, GList **filelist)
 
       if (!filename) continue;
 
-      menuitem = gtk_menu_item_new_with_label (g_path_get_basename(filename));
+      const gchar *bn = g_path_get_basename (filename);
+      menuitem = gtk_menu_item_new_with_label (bn);
+      g_free (bn);
       g_signal_connect (G_OBJECT (menuitem), "activate",
                         G_CALLBACK (func), filename);
       gtk_menu_append (GTK_MENU (menu), menuitem);

--- a/src/help.c
+++ b/src/help.c
@@ -331,9 +331,9 @@ get_dirlist_sub_menu (const gchar *dir, gpointer func, GList **filelist)
 
       if (!filename) continue;
 
-      const gchar *bn = g_path_get_basename (filename);
-      menuitem = gtk_menu_item_new_with_label (bn);
-      g_free (bn);
+      gchar *basename = g_path_get_basename (filename);
+      menuitem = gtk_menu_item_new_with_label (basename);
+      g_free (basename);
       g_signal_connect (G_OBJECT (menuitem), "activate",
                         G_CALLBACK (func), filename);
       gtk_menu_append (GTK_MENU (menu), menuitem);

--- a/src/utils_auto_comp.c
+++ b/src/utils_auto_comp.c
@@ -125,7 +125,7 @@ auto_compl_get_n_alternatives (const gchar *path)
 
    if (path == NULL) return 0;
 
-   filename = g_basename (path);
+   filename = g_path_get_basename (path);
    if (filename && filename[0] == '.') {
       show_dot = TRUE;
       flags = flags | GETDIR_READ_DOT;
@@ -410,7 +410,7 @@ auto_compl_show_alternatives (GtkWidget *entry)
    for (scan = ac_alternatives; scan; scan = scan->next) {
       gtk_list_store_append (ac_list_store, &iter);
       gtk_list_store_set (ac_list_store, &iter,
-                          0, g_basename (scan->data),
+                          0, g_path_get_basename (scan->data),
                           -1);
 
       if (n == 0) {

--- a/src/utils_auto_comp.c
+++ b/src/utils_auto_comp.c
@@ -116,7 +116,7 @@ gint
 auto_compl_get_n_alternatives (const gchar *path)
 {
    gchar *dir;
-   const gchar *filename;
+   gchar *filename;
    gint path_len;
    GList *scan;
    gint n;
@@ -409,12 +409,12 @@ auto_compl_show_alternatives (GtkWidget *entry)
    gtk_list_store_clear (ac_list_store);
 
    for (scan = ac_alternatives; scan; scan = scan->next) {
-      const gchar *bn = g_path_get_basename (scan->data);
+      gchar *basename = g_path_get_basename (scan->data);
       gtk_list_store_append (ac_list_store, &iter);
       gtk_list_store_set (ac_list_store, &iter,
-                          0, bn,
+                          0, basename,
                           -1);
-      g_free (bn);
+      g_free (basename);
 
       if (n == 0) {
          GtkTreeSelection *selection;

--- a/src/utils_auto_comp.c
+++ b/src/utils_auto_comp.c
@@ -132,6 +132,7 @@ auto_compl_get_n_alternatives (const gchar *path)
    } else {
       show_dot = FALSE;
    }
+   g_free (filename);
 
    if (strcmp (path, "/") == 0)
       dir = g_strdup ("/");
@@ -408,10 +409,12 @@ auto_compl_show_alternatives (GtkWidget *entry)
    gtk_list_store_clear (ac_list_store);
 
    for (scan = ac_alternatives; scan; scan = scan->next) {
+      const gchar *bn = g_path_get_basename (scan->data);
       gtk_list_store_append (ac_list_store, &iter);
       gtk_list_store_set (ac_list_store, &iter,
-                          0, g_path_get_basename (scan->data),
+                          0, bn,
                           -1);
+      g_free (bn);
 
       if (n == 0) {
          GtkTreeSelection *selection;

--- a/src/utils_file_gtk.c
+++ b/src/utils_file_gtk.c
@@ -628,7 +628,7 @@ move_file (const gchar *from_path, const gchar *dir,
    if (!retval) return FALSE;
 
    /* set dest path */
-   to_path = g_strconcat (dir, g_basename (from_path), NULL);
+   to_path = g_strconcat (dir, g_path_get_basename (from_path), NULL);
 
    move_file = move_file_check_over_write (from_path, &from_st,
                                            to_path, &to_st,
@@ -847,7 +847,7 @@ copy_dir (const gchar *from_path, const gchar *dir,
    if (dirname[strlen (dirname) - 1] == '/')
       dirname[strlen (dirname) - 1] = '\0';
 
-   to_dir = g_strconcat (dirname, "/", g_basename (from_dir), NULL);
+   to_dir = g_strconcat (dirname, "/", g_path_get_basename (from_dir), NULL);
 
    /*******************
     * check source dir
@@ -1153,7 +1153,7 @@ copy_file (const gchar *from_path, const gchar *dir,
       return FALSE;
    }
 
-   to_path = g_strconcat (dir, g_basename (from_path), NULL);
+   to_path = g_strconcat (dir, g_path_get_basename (from_path), NULL);
    retval = copy_file_to_file (from_path, to_path, action, show_error, window);
    g_free (to_path);
 
@@ -1216,7 +1216,7 @@ link_file (const gchar *from_path, const gchar *dir,
       goto ERROR0;
    }
 
-   to_path = g_strconcat(dir_internal, g_basename(from_path), NULL);
+   to_path = g_strconcat(dir_internal, g_path_get_basename(from_path), NULL);
    to_path_internal = charset_to_internal (to_path,
                                            conf.charset_filename,
                                            conf.charset_auto_detect_fn,
@@ -1275,7 +1275,7 @@ get_dest_cache_dir (const gchar *src_file,
 
    if (!src_file || !dest_dir || !cache_type) return NULL;
 
-   dest_file = g_strconcat (dest_dir, g_basename (src_file), NULL);
+   dest_file = g_strconcat (dest_dir, g_path_get_basename (src_file), NULL);
    dest_cache_dir = gimv_thumb_cache_get_path (dest_file, cache_type);
 
    if (dest_cache_dir) {
@@ -1304,7 +1304,7 @@ get_dest_comment_dir (const gchar *src_file,
 
    if (!src_file || !dest_dir) return NULL;
 
-   dest_file = g_strconcat (dest_dir, g_basename (src_file), NULL);
+   dest_file = g_strconcat (dest_dir, g_path_get_basename (src_file), NULL);
    dest_comment_dir = gimv_comment_get_path (dest_file);
 
    if (dest_comment_dir) {
@@ -1932,7 +1932,7 @@ rename_dir_dialog (const gchar *dir, GtkWindow *window)
    parent_dir = g_dirname (src_path);
 
    /* popup rename directory dialog */
-   src_file_internal = charset_locale_to_internal (g_basename (src_path));
+   src_file_internal = charset_locale_to_internal (g_path_get_basename (src_path));
    dirname = gtkutil_popup_textentry (_("Rename directory"),
                                       _("New directory name: "),
                                       src_file_internal,

--- a/src/utils_file_gtk.c
+++ b/src/utils_file_gtk.c
@@ -628,7 +628,9 @@ move_file (const gchar *from_path, const gchar *dir,
    if (!retval) return FALSE;
 
    /* set dest path */
-   to_path = g_strconcat (dir, g_path_get_basename (from_path), NULL);
+   const gchar *bn = g_path_get_basename (from_path);
+   to_path = g_strconcat (dir, bn, NULL);
+   g_free (bn);
 
    move_file = move_file_check_over_write (from_path, &from_st,
                                            to_path, &to_st,
@@ -847,7 +849,9 @@ copy_dir (const gchar *from_path, const gchar *dir,
    if (dirname[strlen (dirname) - 1] == '/')
       dirname[strlen (dirname) - 1] = '\0';
 
-   to_dir = g_strconcat (dirname, "/", g_path_get_basename (from_dir), NULL);
+   const gchar *bn = g_path_get_basename (from_dir);
+   to_dir = g_strconcat (dirname, "/", bn, NULL);
+   g_free (bn);
 
    /*******************
     * check source dir
@@ -1153,7 +1157,9 @@ copy_file (const gchar *from_path, const gchar *dir,
       return FALSE;
    }
 
-   to_path = g_strconcat (dir, g_path_get_basename (from_path), NULL);
+   const gchar *bn = g_path_get_basename (from_path);
+   to_path = g_strconcat (dir, bn, NULL);
+   g_free (bn);
    retval = copy_file_to_file (from_path, to_path, action, show_error, window);
    g_free (to_path);
 
@@ -1216,7 +1222,9 @@ link_file (const gchar *from_path, const gchar *dir,
       goto ERROR0;
    }
 
-   to_path = g_strconcat(dir_internal, g_path_get_basename(from_path), NULL);
+   const gchar *bn = g_path_get_basename (from_path);
+   to_path = g_strconcat(dir_internal, bn, NULL);
+   g_free (bn);
    to_path_internal = charset_to_internal (to_path,
                                            conf.charset_filename,
                                            conf.charset_auto_detect_fn,
@@ -1275,7 +1283,9 @@ get_dest_cache_dir (const gchar *src_file,
 
    if (!src_file || !dest_dir || !cache_type) return NULL;
 
-   dest_file = g_strconcat (dest_dir, g_path_get_basename (src_file), NULL);
+   const gchar *bn = g_path_get_basename (src_file);
+   dest_file = g_strconcat (dest_dir, bn, NULL);
+   g_free (bn);
    dest_cache_dir = gimv_thumb_cache_get_path (dest_file, cache_type);
 
    if (dest_cache_dir) {
@@ -1304,7 +1314,9 @@ get_dest_comment_dir (const gchar *src_file,
 
    if (!src_file || !dest_dir) return NULL;
 
-   dest_file = g_strconcat (dest_dir, g_path_get_basename (src_file), NULL);
+   const gchar *bn = g_path_get_basename (src_file);
+   dest_file = g_strconcat (dest_dir, bn, NULL);
+   g_free (bn);
    dest_comment_dir = gimv_comment_get_path (dest_file);
 
    if (dest_comment_dir) {
@@ -1932,7 +1944,9 @@ rename_dir_dialog (const gchar *dir, GtkWindow *window)
    parent_dir = g_dirname (src_path);
 
    /* popup rename directory dialog */
-   src_file_internal = charset_locale_to_internal (g_path_get_basename (src_path));
+   const gchar *bn = g_path_get_basename (src_path);
+   src_file_internal = charset_locale_to_internal (bn);
+   g_free (bn);
    dirname = gtkutil_popup_textentry (_("Rename directory"),
                                       _("New directory name: "),
                                       src_file_internal,

--- a/src/utils_file_gtk.c
+++ b/src/utils_file_gtk.c
@@ -628,9 +628,9 @@ move_file (const gchar *from_path, const gchar *dir,
    if (!retval) return FALSE;
 
    /* set dest path */
-   const gchar *bn = g_path_get_basename (from_path);
-   to_path = g_strconcat (dir, bn, NULL);
-   g_free (bn);
+   gchar *basename = g_path_get_basename (from_path);
+   to_path = g_strconcat (dir, basename, NULL);
+   g_free (basename);
 
    move_file = move_file_check_over_write (from_path, &from_st,
                                            to_path, &to_st,
@@ -849,9 +849,9 @@ copy_dir (const gchar *from_path, const gchar *dir,
    if (dirname[strlen (dirname) - 1] == '/')
       dirname[strlen (dirname) - 1] = '\0';
 
-   const gchar *bn = g_path_get_basename (from_dir);
-   to_dir = g_strconcat (dirname, "/", bn, NULL);
-   g_free (bn);
+   gchar *basename = g_path_get_basename (from_dir);
+   to_dir = g_strconcat (dirname, "/", basename, NULL);
+   g_free (basename);
 
    /*******************
     * check source dir
@@ -1157,9 +1157,9 @@ copy_file (const gchar *from_path, const gchar *dir,
       return FALSE;
    }
 
-   const gchar *bn = g_path_get_basename (from_path);
-   to_path = g_strconcat (dir, bn, NULL);
-   g_free (bn);
+   gchar *basename = g_path_get_basename (from_path);
+   to_path = g_strconcat (dir, basename, NULL);
+   g_free (basename);
    retval = copy_file_to_file (from_path, to_path, action, show_error, window);
    g_free (to_path);
 
@@ -1222,9 +1222,9 @@ link_file (const gchar *from_path, const gchar *dir,
       goto ERROR0;
    }
 
-   const gchar *bn = g_path_get_basename (from_path);
-   to_path = g_strconcat(dir_internal, bn, NULL);
-   g_free (bn);
+   gchar *basename = g_path_get_basename (from_path);
+   to_path = g_strconcat(dir_internal, basename, NULL);
+   g_free (basename);
    to_path_internal = charset_to_internal (to_path,
                                            conf.charset_filename,
                                            conf.charset_auto_detect_fn,
@@ -1283,9 +1283,9 @@ get_dest_cache_dir (const gchar *src_file,
 
    if (!src_file || !dest_dir || !cache_type) return NULL;
 
-   const gchar *bn = g_path_get_basename (src_file);
-   dest_file = g_strconcat (dest_dir, bn, NULL);
-   g_free (bn);
+   gchar *basename = g_path_get_basename (src_file);
+   dest_file = g_strconcat (dest_dir, basename, NULL);
+   g_free (basename);
    dest_cache_dir = gimv_thumb_cache_get_path (dest_file, cache_type);
 
    if (dest_cache_dir) {
@@ -1314,9 +1314,9 @@ get_dest_comment_dir (const gchar *src_file,
 
    if (!src_file || !dest_dir) return NULL;
 
-   const gchar *bn = g_path_get_basename (src_file);
-   dest_file = g_strconcat (dest_dir, bn, NULL);
-   g_free (bn);
+   gchar *basename = g_path_get_basename (src_file);
+   dest_file = g_strconcat (dest_dir, basename, NULL);
+   g_free (basename);
    dest_comment_dir = gimv_comment_get_path (dest_file);
 
    if (dest_comment_dir) {
@@ -1944,9 +1944,9 @@ rename_dir_dialog (const gchar *dir, GtkWindow *window)
    parent_dir = g_dirname (src_path);
 
    /* popup rename directory dialog */
-   const gchar *bn = g_path_get_basename (src_path);
-   src_file_internal = charset_locale_to_internal (bn);
-   g_free (bn);
+   gchar *basename = g_path_get_basename (src_path);
+   src_file_internal = charset_locale_to_internal (basename);
+   g_free (basename);
    dirname = gtkutil_popup_textentry (_("Rename directory"),
                                       _("New directory name: "),
                                       src_file_internal,

--- a/src/utils_gtk.c
+++ b/src/utils_gtk.c
@@ -438,7 +438,7 @@ cb_show_image2 (GtkButton *button, OverWriteDialog *dialog)
 static void
 overwrite_confirm_rename (OverWriteDialog *dialog)
 {
-   const gchar *filename_internal
+   gchar *filename_internal
       = g_path_get_basename (gtk_entry_get_text (GTK_ENTRY (dialog->entry)));
    gchar *dirname, *filename;
 

--- a/src/utils_gtk.c
+++ b/src/utils_gtk.c
@@ -451,6 +451,7 @@ overwrite_confirm_rename (OverWriteDialog *dialog)
    g_return_if_fail (*dirname);
 
    filename = charset_internal_to_locale (filename_internal);
+   g_free (filename_internal);
    g_return_if_fail (filename);
    if (!*filename) g_free (filename);
    g_return_if_fail (*filename);
@@ -633,10 +634,12 @@ gtkutil_overwrite_confirm_dialog (const gchar *title, const gchar *message,
    gtk_box_pack_start (GTK_BOX (hbox), entry, TRUE, TRUE, 0);
    g_signal_connect (G_OBJECT (entry), "activate",
                      G_CALLBACK (cb_confirm_rename_enter), &dialog);
-   filename = charset_to_internal (g_path_get_basename (src_file),
+   const gchar *bn = g_path_get_basename (src_file);
+   filename = charset_to_internal (bn,
                                    conf.charset_filename,
                                    conf.charset_auto_detect_fn,
                                    conf.charset_filename_mode);
+   g_free (bn);
    gtk_entry_set_text (GTK_ENTRY (entry), filename);
    g_free (filename);
    filename = NULL;

--- a/src/utils_gtk.c
+++ b/src/utils_gtk.c
@@ -439,7 +439,7 @@ static void
 overwrite_confirm_rename (OverWriteDialog *dialog)
 {
    const gchar *filename_internal
-      = g_basename (gtk_entry_get_text (GTK_ENTRY (dialog->entry)));
+      = g_path_get_basename (gtk_entry_get_text (GTK_ENTRY (dialog->entry)));
    gchar *dirname, *filename;
 
    if (!filename_internal && *filename_internal) return;
@@ -633,7 +633,7 @@ gtkutil_overwrite_confirm_dialog (const gchar *title, const gchar *message,
    gtk_box_pack_start (GTK_BOX (hbox), entry, TRUE, TRUE, 0);
    g_signal_connect (G_OBJECT (entry), "activate",
                      G_CALLBACK (cb_confirm_rename_enter), &dialog);
-   filename = charset_to_internal (g_basename (src_file),
+   filename = charset_to_internal (g_path_get_basename (src_file),
                                    conf.charset_filename,
                                    conf.charset_auto_detect_fn,
                                    conf.charset_filename_mode);

--- a/src/utils_gtk.c
+++ b/src/utils_gtk.c
@@ -634,12 +634,12 @@ gtkutil_overwrite_confirm_dialog (const gchar *title, const gchar *message,
    gtk_box_pack_start (GTK_BOX (hbox), entry, TRUE, TRUE, 0);
    g_signal_connect (G_OBJECT (entry), "activate",
                      G_CALLBACK (cb_confirm_rename_enter), &dialog);
-   const gchar *bn = g_path_get_basename (src_file);
-   filename = charset_to_internal (bn,
+   gchar *basename = g_path_get_basename (src_file);
+   filename = charset_to_internal (basename,
                                    conf.charset_filename,
                                    conf.charset_auto_detect_fn,
                                    conf.charset_filename_mode);
-   g_free (bn);
+   g_free (basename);
    gtk_entry_set_text (GTK_ENTRY (entry), filename);
    g_free (filename);
    filename = NULL;


### PR DESCRIPTION
文章を英語で書くのが難しいと感じるので、日本語で書きます。
いくつかのソースコードにおいて、g_basename()が使われていたので、g_path_get_basename()に変更しました。